### PR TITLE
Correct inconsistencies w/ ckey entry handling

### DIFF
--- a/frontend/src/components/authentikPanel.tsx
+++ b/frontend/src/components/authentikPanel.tsx
@@ -92,13 +92,17 @@ export const AuthentikPanel: React.FC = () => {
   const handleAddUser = async () => {
     if (!addCkey.trim()) return;
 
+    const re = /[^a-z0-9@]/g;
+    const userCkeyChecked = addCkey.trim().toLowerCase().replace(re, "");
+    if (!userCkeyChecked) return;
+
     setAddLoading(true);
     try {
       const response = await callApi("/Authentik/AddUserToGroup", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          ckey: addCkey.trim(),
+          ckey: userCkeyChecked,
           group_name: selectedGroup,
         }),
       });
@@ -108,7 +112,7 @@ export const AuthentikPanel: React.FC = () => {
         throw new Error(err.message || "Failed to add user to group");
       }
 
-      global?.updateAndShowToast(`Added ${addCkey} to ${selectedGroup}`);
+      global?.updateAndShowToast(`Added ${userCkeyChecked} to ${selectedGroup}`);
       setShowAddDialog(false);
       setAddCkey("");
       fetchGroupMembers(selectedGroup);

--- a/frontend/src/components/userLookup.tsx
+++ b/frontend/src/components/userLookup.tsx
@@ -53,8 +53,8 @@ export const LookupMenu: React.FC<LookupMenuProps> = (
     (args: UpdateUserArguments) => {
       const { userCkey, userDiscordId } = args;
       setLoading(true);
-      const re = /[\\^]|[^a-z0-9@]/g;
-      const userCkeyChecked = userCkey?.toLowerCase().replace(re, "");
+      const re = /[^a-z0-9@]/g;
+      const userCkeyChecked = userCkey?.trim().toLowerCase().replace(re, "");
       callApi(
         userCkeyChecked
           ? `/User?ckey=${userCkeyChecked}`
@@ -92,8 +92,9 @@ export const LookupMenu: React.FC<LookupMenuProps> = (
 
     if (!potentialUser) return;
 
-    const re = /[\\^]|[^a-z0-9@]/g;
-    const checked = potentialUser.toLowerCase().replace(re, "");
+    const re = /[^a-z0-9@]/g;
+    const checked = potentialUser.trim().toLowerCase().replace(re, "");
+    if (!potentialUser) return;
 
     if (potentialUser && (!userData || userData.ckey !== checked)) {
       updateUser({ userCkey: potentialUser as string });
@@ -1184,7 +1185,9 @@ const KnownAltsModal = (props: { player: Player }) => {
     if (!player.ckey || !newAltCkey.trim()) return;
 
     const playerCkey = altsData?.mainAccount || player.ckey;
-    const altCkey = newAltCkey.trim().toLowerCase().replace(/[^a-z0-9@]/g, "");
+    const re = /[^a-z0-9@]/g;
+    const altCkey = newAltCkey.trim().toLowerCase().replace(re, "");
+    if (!altCkey) return;
 
     callApi("/User/KnownAlts", {
       method: "POST",

--- a/frontend/src/components/userLookup.tsx
+++ b/frontend/src/components/userLookup.tsx
@@ -94,9 +94,8 @@ export const LookupMenu: React.FC<LookupMenuProps> = (
 
     const re = /[^a-z0-9@]/g;
     const checked = potentialUser.trim().toLowerCase().replace(re, "");
-    if (!potentialUser) return;
 
-    if (potentialUser && (!userData || userData.ckey !== checked)) {
+    if (!userData || userData.ckey !== checked) {
       updateUser({ userCkey: potentialUser as string });
     }
   }, [value, userData, discordId, updateUser, potentialUser, user, loading]);

--- a/frontend/src/components/userLookup.tsx
+++ b/frontend/src/components/userLookup.tsx
@@ -94,6 +94,7 @@ export const LookupMenu: React.FC<LookupMenuProps> = (
 
     const re = /[^a-z0-9@]/g;
     const checked = potentialUser.trim().toLowerCase().replace(re, "");
+    if(!checked) return;
 
     if (!userData || userData.ckey !== checked) {
       updateUser({ userCkey: potentialUser as string });


### PR DESCRIPTION
This PR does a few things:
- Removes unnecessary regex alternative condition looking for either `\` or `^` when that is already included in the any symbol that isn't a-z, 0-9, @ via `[^a-z0-9@]`
- Adds some missing cases where trim was not performed
- Reasserts that the ckey is not entirely comprised of invalid symbols w/ early returns
- Adds the same ckey handling to user group manager when adding a user.